### PR TITLE
Fixes and cleanup

### DIFF
--- a/.github/workflows/auto-update.yaml
+++ b/.github/workflows/auto-update.yaml
@@ -30,10 +30,10 @@ jobs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
       has-updates: ${{ steps.build-matrix.outputs.has-updates }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
 
       - name: Build update matrix
         id: build-matrix
@@ -57,18 +57,18 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           github_access_token: ${{ steps.app-token.outputs.token }}
 

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -4,6 +4,7 @@ name: Nix Flake Check
 on:
   workflow_dispatch:
   push:
+    branches: [main]
   pull_request:
 jobs:
   nix-flake-check:
@@ -13,9 +14,11 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install nix
-        uses: cachix/install-nix-action@v30
+        uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            accept-flake-config = true
 
       - name: Run nix flake check
         run: nix flake check

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -39,10 +39,10 @@ jobs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
       has-updates: ${{ steps.build-matrix.outputs.has-updates }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
 
       - name: Build update matrix
         id: build-matrix
@@ -66,18 +66,18 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           github_access_token: ${{ steps.app-token.outputs.token }}
 

--- a/README.md
+++ b/README.md
@@ -127,11 +127,10 @@ $ nix run avim#avim
 | `<leader>uu` | Toggle undotree | Toggle undo tree |
 | `<leader>H` | Home screen | Toggle dashboard |
 
-### Terminal and AI
+### Terminal
 
 | Key | Action | Description |
 |-----|--------|-------------|
-| `<F8>` | Toggle Codex | Open Codex in floating terminal |
 | `<F9>`-`<F12>` | Toggle terminal 1-4 | Dedicated floating terminals |
 | `<C-\>` | Toggle terminal | Toggle floating terminal |
 | `<leader>gg` | Open LazyGit | Open LazyGit in terminal |

--- a/README.md
+++ b/README.md
@@ -131,9 +131,6 @@ $ nix run avim#avim
 
 | Key | Action | Description |
 |-----|--------|-------------|
-| `<F5>` | Toggle Claude Code | Open Claude Code AI assistant |
-| `<S-F5>` | Continue Claude Code | Continue Claude Code conversation |
-| `<F7>` | Toggle OpenCode | Open OpenCode |
 | `<F8>` | Toggle Codex | Open Codex in floating terminal |
 | `<F9>`-`<F12>` | Toggle terminal 1-4 | Dedicated floating terminals |
 | `<C-\>` | Toggle terminal | Toggle floating terminal |

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Having my Neovim configuration ready as a `flake` allows me to run `nvim` alread
 You can add the following registry shortcut to type less characters:
 
 ```console
-$ nix registry add avim github:aldoborrero/astronvim.nix
+$ nix registry add avim github:aldoborrero/avim.nix
 ```
 
 ## Running avim
@@ -62,7 +62,6 @@ $ nix run avim#avim
 | `<leader>fb` | Find buffers | Search open buffers |
 | `<leader>fo` | Find old files | Recent files |
 | `<leader>fO` | Find old files (cwd) | Recent files in current directory |
-| `<leader>fa` | Find config files | Search config files |
 | `<leader>fh` | Find help | Search help tags |
 | `<leader>fc` | Find word under cursor | Search current word |
 | `<leader>fC` | Find commands | Search available commands |
@@ -107,7 +106,8 @@ $ nix run avim#avim
 | `<leader>lr` | Rename symbol | Rename symbol |
 | `<leader>lf` | Format buffer | Format code |
 | `<leader>lD` | Search diagnostics | Search diagnostics |
-| `<leader>ls` | Search symbols | Search LSP symbols |
+| `<leader>lw` | Workspace symbols | Search LSP symbols |
+| `]d` / `[d` | Next/prev diagnostic | Jump between diagnostics |
 
 ### Search and Replace
 
@@ -131,10 +131,15 @@ $ nix run avim#avim
 
 | Key | Action | Description |
 |-----|--------|-------------|
-| `<F4>` | Open Claude Code | Open Claude Code AI assistant |
-| `<F5>` | Continue conversation | Continue Claude Code conversation |
-| `<F6>` | Open LazyGit | Open LazyGit in terminal |
-| `<F7>` | Toggle terminal | Toggle floating terminal |
+| `<F5>` | Toggle Claude Code | Open Claude Code AI assistant |
+| `<S-F5>` | Continue Claude Code | Continue Claude Code conversation |
+| `<F6>` | Toggle Pi Agent | Open Pi Agent |
+| `<S-F6>` | Continue Pi Agent | Continue Pi Agent conversation |
+| `<F7>` | Toggle OpenCode | Open OpenCode |
+| `<F8>` | Toggle Codex | Open Codex in floating terminal |
+| `<F9>`-`<F12>` | Toggle terminal 1-4 | Dedicated floating terminals |
+| `<C-\>` | Toggle terminal | Toggle floating terminal |
+| `<leader>gg` | Open LazyGit | Open LazyGit in terminal |
 | `<Esc><Esc>` | Exit terminal mode | Exit to normal mode (in terminal) |
 
 ### Window Management
@@ -178,4 +183,4 @@ Thanks to mighty @Mic92 to whom I took inspiration (and stole majority of his co
 
 ## License
 
-See [License](License) for more information.
+See [LICENSE](LICENSE) for more information.

--- a/README.md
+++ b/README.md
@@ -133,8 +133,6 @@ $ nix run avim#avim
 |-----|--------|-------------|
 | `<F5>` | Toggle Claude Code | Open Claude Code AI assistant |
 | `<S-F5>` | Continue Claude Code | Continue Claude Code conversation |
-| `<F6>` | Toggle Pi Agent | Open Pi Agent |
-| `<S-F6>` | Continue Pi Agent | Continue Pi Agent conversation |
 | `<F7>` | Toggle OpenCode | Open OpenCode |
 | `<F8>` | Toggle Codex | Open Codex in floating terminal |
 | `<F9>`-`<F12>` | Toggle terminal 1-4 | Dedicated floating terminals |

--- a/flake.lock
+++ b/flake.lock
@@ -21,28 +21,6 @@
         "type": "github"
       }
     },
-    "blueprint_2": {
-      "inputs": {
-        "nixpkgs": [
-          "pi-agent-nvim",
-          "nixpkgs"
-        ],
-        "systems": "systems_3"
-      },
-      "locked": {
-        "lastModified": 1769353768,
-        "narHash": "sha256-zI+7cbMI4wMIR57jMjDSEsVb3grapTnURDxxJPYFIW0=",
-        "owner": "numtide",
-        "repo": "blueprint",
-        "rev": "c7da5c70ad1c9b60b6f5d4f674fbe205d48d8f6c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "blueprint",
-        "type": "github"
-      }
-    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
@@ -56,28 +34,6 @@
         "owner": "hercules-ci",
         "repo": "flake-parts",
         "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-parts_2": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "pi-agent-nvim",
-          "nixvim",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1768135262,
-        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
         "type": "github"
       },
       "original": {
@@ -124,37 +80,20 @@
         "type": "github"
       }
     },
-    "nixvim_2": {
-      "inputs": {
-        "flake-parts": "flake-parts_2",
-        "nixpkgs": [
-          "pi-agent-nvim",
-          "nixpkgs"
-        ],
-        "systems": "systems_4"
-      },
-      "locked": {
-        "lastModified": 1770025103,
-        "narHash": "sha256-Qlb19PP0n6s+v1MywVjROV5XwsCvA58XXiXHk0Govb4=",
-        "owner": "nix-community",
-        "repo": "nixvim",
-        "rev": "31c3b3687dc85e3fbbf5c44728a5ee231608f8a9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixvim",
-        "type": "github"
-      }
-    },
     "pi-agent-nvim": {
       "inputs": {
-        "blueprint": "blueprint_2",
+        "blueprint": [
+          "blueprint"
+        ],
         "nixpkgs": [
           "nixpkgs"
         ],
-        "nixvim": "nixvim_2",
-        "treefmt-nix": "treefmt-nix"
+        "nixvim": [
+          "nixvim"
+        ],
+        "treefmt-nix": [
+          "treefmt-nix"
+        ]
       },
       "locked": {
         "lastModified": 1770580159,
@@ -176,7 +115,7 @@
         "nixpkgs": "nixpkgs",
         "nixvim": "nixvim",
         "pi-agent-nvim": "pi-agent-nvim",
-        "treefmt-nix": "treefmt-nix_2"
+        "treefmt-nix": "treefmt-nix"
       }
     },
     "systems": {
@@ -209,58 +148,7 @@
         "type": "github"
       }
     },
-    "systems_3": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_4": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
     "treefmt-nix": {
-      "inputs": {
-        "nixpkgs": [
-          "pi-agent-nvim",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1769691507,
-        "narHash": "sha256-8aAYwyVzSSwIhP2glDhw/G0i5+wOrren3v6WmxkVonM=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "28b19c5844cc6e2257801d43f2772a4b4c050a1b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "type": "github"
-      }
-    },
-    "treefmt-nix_2": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"

--- a/flake.lock
+++ b/flake.lock
@@ -80,41 +80,11 @@
         "type": "github"
       }
     },
-    "pi-agent-nvim": {
-      "inputs": {
-        "blueprint": [
-          "blueprint"
-        ],
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "nixvim": [
-          "nixvim"
-        ],
-        "treefmt-nix": [
-          "treefmt-nix"
-        ]
-      },
-      "locked": {
-        "lastModified": 1770580159,
-        "narHash": "sha256-fUFC1Xqy3yXoBjLCYjXQSk7ymRzpItixYrzSCbrz/TE=",
-        "owner": "aldoborrero",
-        "repo": "pi-agent.nvim",
-        "rev": "4c169487344efa98dffef57a09452c1393c09f64",
-        "type": "github"
-      },
-      "original": {
-        "owner": "aldoborrero",
-        "repo": "pi-agent.nvim",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "blueprint": "blueprint",
         "nixpkgs": "nixpkgs",
         "nixvim": "nixvim",
-        "pi-agent-nvim": "pi-agent-nvim",
         "treefmt-nix": "treefmt-nix"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1771437256,
-        "narHash": "sha256-bLqwib+rtyBRRVBWhMuBXPCL/OThfokA+j6+uH7jDGU=",
+        "lastModified": 1776249299,
+        "narHash": "sha256-Dt9t1TGRmJFc0xVYhttNBD6QsAgHOHCArqGa0AyjrJY=",
         "owner": "numtide",
         "repo": "blueprint",
-        "rev": "06ee7190dc2620ea98af9eb225aa9627b68b0e33",
+        "rev": "56131e8628f173d24a27f6d27c0215eff57e40dd",
         "type": "github"
       },
       "original": {
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769996383,
-        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
@@ -44,11 +44,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771848320,
-        "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
+        "lastModified": 1780749050,
+        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
+        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1772402258,
-        "narHash": "sha256-3DmCFOdmbkFML1/G9gj8Wb+rCCZFPOQtNoMCpqOF8SA=",
+        "lastModified": 1781034432,
+        "narHash": "sha256-+UuS36un3lXLtKsGCYQnOn51hDhB+dZ1SHoHXClnV/0=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "21ae25e13b01d3b4cdc750b5f9e7bad68b150c10",
+        "rev": "e9fbbd56eab78751ba4c166c31a1667042528ced",
         "type": "github"
       },
       "original": {
@@ -135,15 +135,16 @@
     },
     "systems_2": {
       "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "lastModified": 1774449309,
+        "narHash": "sha256-brhZ8DmuGtzkCYHJg4HEd602amKm89Y9ytsFZ5uWD1w=",
         "owner": "nix-systems",
         "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "rev": "c29398b59d2048c4ab79345812849c9bd15e9150",
         "type": "github"
       },
       "original": {
         "owner": "nix-systems",
+        "ref": "future-26.11",
         "repo": "default",
         "type": "github"
       }
@@ -155,11 +156,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770228511,
-        "narHash": "sha256-wQ6NJSuFqAEmIg2VMnLdCnUc0b7vslUohqqGGD+Fyxk=",
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "337a4fe074be1042a35086f15481d763b8ddc0e7",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "astronvim.nix / My personal astronvim configuration";
+  description = "avim.nix / My personal Neovim configuration";
 
   nixConfig = {
     extra-substituters = [
@@ -30,7 +30,12 @@
     };
     pi-agent-nvim = {
       url = "github:aldoborrero/pi-agent.nvim";
-      inputs.nixpkgs.follows = "nixpkgs";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        nixvim.follows = "nixvim";
+        blueprint.follows = "blueprint";
+        treefmt-nix.follows = "treefmt-nix";
+      };
     };
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -28,15 +28,6 @@
       url = "github:nix-community/nixvim";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    pi-agent-nvim = {
-      url = "github:aldoborrero/pi-agent.nvim";
-      inputs = {
-        nixpkgs.follows = "nixpkgs";
-        nixvim.follows = "nixvim";
-        blueprint.follows = "blueprint";
-        treefmt-nix.follows = "treefmt-nix";
-      };
-    };
   };
 
   outputs =

--- a/packages/avim/config.nix
+++ b/packages/avim/config.nix
@@ -404,17 +404,23 @@
       options.desc = "Search in current file";
     }
 
-    # Comments
+    # Comments (builtin commenting, Neovim 0.10+)
     {
       key = "<leader>/";
-      action.__raw = "function() require('Comment.api').toggle.linewise.current() end";
-      options.desc = "Toggle comment";
+      action = "gcc";
+      options = {
+        remap = true;
+        desc = "Toggle comment";
+      };
     }
     {
       mode = "v";
       key = "<leader>/";
-      action.__raw = "function() require('Comment.api').toggle.linewise(vim.fn.visualmode()) end";
-      options.desc = "Toggle comment";
+      action = "gc";
+      options = {
+        remap = true;
+        desc = "Toggle comment";
+      };
     }
 
     # Snacks utilities
@@ -578,12 +584,12 @@
     # Diagnostic Navigation
     {
       key = "]d";
-      action = "<cmd>lua vim.diagnostic.goto_next()<CR>";
+      action.__raw = "function() vim.diagnostic.jump({ count = 1, float = true }) end";
       options.desc = "Next diagnostic";
     }
     {
       key = "[d";
-      action = "<cmd>lua vim.diagnostic.goto_prev()<CR>";
+      action.__raw = "function() vim.diagnostic.jump({ count = -1, float = true }) end";
       options.desc = "Previous diagnostic";
     }
 
@@ -592,7 +598,11 @@
       key = "gp";
       action.__raw = ''
         function()
-          local params = vim.lsp.util.make_position_params()
+          local client = vim.lsp.get_clients({ bufnr = 0 })[1]
+          if not client then
+            return
+          end
+          local params = vim.lsp.util.make_position_params(0, client.offset_encoding)
           return vim.lsp.buf_request(0, 'textDocument/definition', params, function(_, result)
             if result == nil or vim.tbl_isempty(result) then
               return nil
@@ -930,7 +940,7 @@
       key = "<C-l>";
       action.__raw = ''
         function()
-          if require("luasnip").jumpable(1) then
+          if require("luasnip").locally_jumpable(1) then
             require("luasnip").jump(1)
           end
         end
@@ -948,7 +958,7 @@
       key = "<C-h>";
       action.__raw = ''
         function()
-          if require("luasnip").jumpable(-1) then
+          if require("luasnip").locally_jumpable(-1) then
             require("luasnip").jump(-1)
           end
         end
@@ -1049,11 +1059,11 @@
             "accept"
             "fallback"
           ];
-          "<C-k>" = [
+          "<C-j>" = [
             "select_next"
             "fallback"
           ];
-          "<C-j>" = [
+          "<C-k>" = [
             "select_prev"
             "fallback"
           ];
@@ -1112,18 +1122,7 @@
         fuzzy = {
           prebuilt_binaries.download = true;
         };
-        snippets = {
-          expand.__raw = "function(snippet) require('luasnip').lsp_expand(snippet) end";
-          active.__raw = ''
-            function(filter)
-              if filter and filter.direction then
-                return require("luasnip").jumpable(filter.direction)
-              end
-              return require("luasnip").in_snippet()
-            end
-          '';
-          jump.__raw = "function(direction) require('luasnip').jump(direction) end";
-        };
+        snippets.preset = "luasnip";
       };
     };
 
@@ -1280,8 +1279,6 @@
       };
     };
 
-    alpha.enable = false;
-
     gitsigns = {
       enable = true;
       settings = {
@@ -1311,8 +1308,6 @@
 
     nvim-autopairs.enable = true;
 
-    comment.enable = true;
-
     nvim-surround = {
       enable = true;
       settings = {
@@ -1331,8 +1326,6 @@
         };
       };
     };
-
-    indent-blankline.enable = true;
 
     toggleterm = {
       enable = true;
@@ -1603,11 +1596,6 @@
 
     harpoon = {
       enable = true;
-      enableTelescope = false;
-    };
-
-    project-nvim = {
-      enable = false;
       enableTelescope = false;
     };
 

--- a/packages/avim/config.nix
+++ b/packages/avim/config.nix
@@ -1,9 +1,5 @@
-{ pkgs, inputs }:
+{ pkgs, ... }:
 {
-  imports = [
-    inputs.pi-agent-nvim.modules.nixvim.default
-  ];
-
   globals = {
     mapleader = " ";
     maplocalleader = ",";
@@ -684,16 +680,6 @@
       key = "<F17>";
       action = "<cmd>ClaudeCodeContinue<CR>";
       options.desc = "Continue Claude Code (Shift+F5)";
-    }
-    {
-      key = "<F6>";
-      action = "<cmd>PiAgent<CR>";
-      options.desc = "Toggle Pi Agent";
-    }
-    {
-      key = "<F18>";
-      action = "<cmd>PiAgentContinue<CR>";
-      options.desc = "Continue Pi Agent (Shift+F6)";
     }
     {
       key = "<F7>";
@@ -1611,16 +1597,6 @@
           position = "horizontal";
           hide_numbers = false;
           hide_signcolumn = false;
-        };
-      };
-    };
-
-    pi-agent = {
-      enable = true;
-      settings = {
-        window = {
-          split_ratio = 0.4;
-          position = "botright";
         };
       };
     };

--- a/packages/avim/config.nix
+++ b/packages/avim/config.nix
@@ -670,22 +670,7 @@
       options.desc = "Diagnostic quickfix";
     }
 
-    # AI Tools (F5-F8)
-    {
-      key = "<F5>";
-      action = "<cmd>ClaudeCode<CR>";
-      options.desc = "Toggle Claude Code";
-    }
-    {
-      key = "<F17>";
-      action = "<cmd>ClaudeCodeContinue<CR>";
-      options.desc = "Continue Claude Code (Shift+F5)";
-    }
-    {
-      key = "<F7>";
-      action.__raw = "function() require('opencode').toggle() end";
-      options.desc = "Toggle OpenCode";
-    }
+    # AI Tools (F8)
     {
       key = "<F8>";
       action.__raw = ''
@@ -1589,18 +1574,6 @@
       enable = true;
     };
 
-    claude-code = {
-      enable = true;
-      settings = {
-        window = {
-          split_ratio = 0.4;
-          position = "horizontal";
-          hide_numbers = false;
-          hide_signcolumn = false;
-        };
-      };
-    };
-
     spectre.enable = true;
 
     conform-nvim = {
@@ -1642,8 +1615,6 @@
         notify_on_error = true;
       };
     };
-
-    opencode.enable = true;
   };
 
   # Autocommands

--- a/packages/avim/config.nix
+++ b/packages/avim/config.nix
@@ -670,37 +670,6 @@
       options.desc = "Diagnostic quickfix";
     }
 
-    # AI Tools (F8)
-    {
-      key = "<F8>";
-      action.__raw = ''
-        function()
-          local Terminal = require('toggleterm.terminal').Terminal
-          if not _G.codex_term then
-            _G.codex_term = Terminal:new({
-              cmd = 'codex',
-              count = 8,
-              direction = 'float',
-              hidden = true,
-              float_opts = { border = 'curved' }
-            })
-          end
-          _G.codex_term:toggle()
-        end
-      '';
-      options.desc = "Toggle Codex";
-    }
-    {
-      mode = "t";
-      key = "<F8>";
-      action.__raw = ''
-        function()
-          if _G.codex_term then _G.codex_term:toggle() end
-        end
-      '';
-      options.desc = "Toggle Codex";
-    }
-
     # Git
     {
       key = "<leader>gg";

--- a/packages/avim/default.nix
+++ b/packages/avim/default.nix
@@ -6,7 +6,7 @@
 with pkgs;
 let
   nvim-appname = "avim";
-  version = "2025.09.21.0";
+  version = "2026.06.10.0";
 
   nvim = inputs.nixvim.legacyPackages.${pkgs.stdenv.hostPlatform.system}.makeNixvimWithModule {
     inherit pkgs;
@@ -28,7 +28,7 @@ let
     inherit version;
     meta = (old.meta or { }) // {
       description = "Avim - Custom Neovim configuration";
-      homepage = "https://github.com/aldoborrero/astronvim.nix";
+      homepage = "https://github.com/aldoborrero/avim.nix";
       license = lib.licenses.mit;
     };
   });

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", "schedule:weekly"],
   "nix": {
-    "enabled": true
+    "enabled": false
   }
 }


### PR DESCRIPTION
## Summary
- Fix keymap bugs and migrate off deprecated APIs: `vim.diagnostic.jump()` instead of `goto_next/goto_prev`, `make_position_params` with explicit offset encoding, luasnip `locally_jumpable`, blink.cmp `snippets.preset = "luasnip"`, and swap `<C-j>`/`<C-k>` completion navigation to the conventional directions
- Replace Comment.nvim with Neovim 0.10+ builtin commenting; remove disabled/unused plugins (alpha, indent-blankline, project-nvim)
- Remove all AI tool integrations: pi-agent-nvim (flake input, module import, config), claude-code, opencode, and the Codex terminal keymaps (F5-F8 are now unbound)
- Update all flake inputs and bump package version to 2026.06.10.0
- Pin all GitHub Actions to commit SHAs and update them to latest (checkout v6.0.3, install-nix-action v31.10.6, create-github-app-token v3.2.0)
- Sync README with actual keymaps; fix stale astronvim.nix references and LICENSE link
- CI: run flake check only on main pushes and PRs, accept flake config; disable Renovate nix updates

## Test plan
- [ ] `nix flake check` passes
- [ ] `nix build .#avim` succeeds
- [ ] `nix run .#avim` starts and `<leader>/` toggles comments in normal and visual mode
- [ ] `]d` / `[d` jump between diagnostics with float
- [ ] Snippet jumps via `<C-l>` / `<C-h>` still work
- [ ] F9-F12 terminal toggles and `<C-\>` work; F5-F8 no longer bound