### PR TITLE
Bundle formatter binaries and fix conform/keymap issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ nix run avim#avim
 | `]b` | Next buffer | Switch to next buffer |
 | `[b` | Previous buffer | Switch to previous buffer |
 | `s` | Flash jump | Jump to location with flash.nvim |
-| `S` | Flash treesitter | Jump with treesitter nodes |
+| `S` | Flash treesitter | Jump with treesitter nodes (normal/operator mode) |
 
 ### File Management
 

--- a/packages/avim/config.nix
+++ b/packages/avim/config.nix
@@ -5,6 +5,22 @@
     maplocalleader = ",";
   };
 
+  # Runtime dependencies for conform formatters and the lazygit keymap,
+  # so the package is self-contained wherever the flake runs
+  extraPackages = with pkgs; [
+    deno
+    gofumpt
+    gotools
+    lazygit
+    nixfmt-rfc-style
+    prettier
+    ruff
+    rustfmt
+    shfmt
+    stylua
+    taplo
+  ];
+
   colorschemes.catppuccin.enable = true;
 
   opts = {
@@ -497,9 +513,9 @@
     }
     {
       key = "S";
+      # visual mode excluded so nvim-surround keeps S for surrounding selections
       mode = [
         "n"
-        "x"
         "o"
       ];
       action.__raw = "function() require('flash').treesitter() end";
@@ -621,13 +637,13 @@
     }
     {
       key = "<leader>lf";
-      action.__raw = "function() require('conform').format({ async = true, lsp_fallback = true }) end";
+      action.__raw = "function() require('conform').format({ async = true, lsp_format = 'fallback' }) end";
       options.desc = "Format buffer";
     }
     {
       mode = "v";
       key = "<leader>lf";
-      action.__raw = "function() require('conform').format({ async = true, lsp_fallback = true, range = { start = vim.api.nvim_buf_get_mark(0, '<'), ['end'] = vim.api.nvim_buf_get_mark(0, '>') } }) end";
+      action.__raw = "function() require('conform').format({ async = true, lsp_format = 'fallback', range = { start = vim.api.nvim_buf_get_mark(0, '<'), ['end'] = vim.api.nvim_buf_get_mark(0, '>') } }) end";
       options.desc = "Format selection";
     }
     {
@@ -1555,7 +1571,7 @@
             "goimports"
           ];
           html = [ "prettier" ];
-          javascript = [ "deno" ];
+          javascript = [ "deno_fmt" ];
           json = [ "prettier" ];
           lua = [ "stylua" ];
           markdown = [ "prettier" ];
@@ -1577,7 +1593,7 @@
             if vim.g.disable_autoformat then
               return
             end
-            return { lsp_fallback = true }
+            return { lsp_format = "fallback" }
           end
         '';
         log_level = "warn";


### PR DESCRIPTION
## Summary
Confirmed findings from a config-quality review:

- **Format-on-save was broken out of the box**: `conform.formatters_by_ft` references ten formatter binaries that were never bundled, so formatting silently failed anywhere the host didn't have them. They now ship via `extraPackages` (verified each lands on the nvim wrapper PATH). `lazygit` is also bundled for the `<leader>gg` keymap. `terraform` is deliberately not bundled (unfree license).
- **`javascript = ["deno"]`** is not a valid conform builtin — corrected to `deno_fmt` (typescript already used it).
- **Visual-mode `S` was bound twice**: flash.nvim's treesitter jump silently shadowed nvim-surround's surround-selection. Flash's `S` is now normal/operator-pending only, so surrounding a visual selection works again.
- **Deprecated `lsp_fallback = true`** replaced with `lsp_format = "fallback"` in all three places before a future conform update turns the deprecation into an error.

## Test plan
- [ ] `nix flake check` passes (verified locally)
- [ ] `nix build .#avim` and confirm `:lua print(vim.fn.executable('stylua'), vim.fn.executable('prettier'), vim.fn.executable('lazygit'))` prints `1 1 1`
- [ ] Format a .nix/.lua/.md buffer with `<leader>lf` and on save
- [ ] Select text in visual mode, press `S` then a delimiter — surround works
- [ ] `<leader>gg` opens LazyGit on a machine without lazygit installed