### PR TITLE
README: correct F9-F12 terminal numbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ $ nix run avim#avim
 
 | Key | Action | Description |
 |-----|--------|-------------|
-| `<F9>`-`<F12>` | Toggle terminal 1-4 | Dedicated floating terminals |
+| `<F9>`-`<F12>` | Toggle terminal 9-12 | Dedicated floating terminals (toggleterm 9-12) |
 | `<C-\>` | Toggle terminal | Toggle floating terminal |
 | `<leader>gg` | Open LazyGit | Open LazyGit in terminal |
 | `<Esc><Esc>` | Exit terminal mode | Exit to normal mode (in terminal) |


### PR DESCRIPTION
## Summary
- The F9-F12 keymaps create toggleterm terminals with IDs 9-12, but the README row said "terminal 1-4"; correct the numbering

Note: carries the `dependencies` label intentionally to exercise the Mergify auto-merge path end to end after the queue fix.

## Test plan
- [ ] Mergify queues and merges this PR automatically once nix-flake-check passes