### PR TITLE
Cache the Nix store in CI with cache-nix-action

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -6,6 +6,16 @@ on:
   push:
     branches: [main]
   pull_request:
+
+concurrency:
+  group: check-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  # cache-nix-action purges old caches through the Actions API
+  actions: write
+
 jobs:
   nix-flake-check:
     runs-on: ubuntu-latest
@@ -14,11 +24,26 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install nix
-        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
+        uses: nixbuild/nix-quick-install-action@2c9db80fb984ceb1bcaa77cdda3fdf8cfba92035 # v34
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
-          extra_nix_config: |
-            accept-flake-config = true
+          # Substituters are enumerated here instead of accept-flake-config so
+          # PR-controlled flake.nix content cannot point CI at untrusted caches
+          nix_conf: |
+            extra-substituters = https://nix-community.cachix.org https://numtide.cachix.org
+            extra-trusted-public-keys = nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs= numtide.cachix.org-1:2ps1kLBUWjxIneOy1Ik6cQjb41X0iXVXeHigGmycPPE=
+            keep-env-derivations = true
+            keep-outputs = true
+
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 5G
+          purge: true
+          purge-prefixes: nix-${{ runner.os }}-
+          purge-created: 0
+          purge-primary-key: never
 
       - name: Run nix flake check
         run: nix flake check

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,8 @@ on:
 
 permissions:
   contents: write
+  # cache-nix-action reads/writes Actions caches
+  actions: write
 
 concurrency:
   group: release
@@ -54,11 +56,21 @@ jobs:
 
       - name: Install nix
         if: steps.check.outputs.skip != 'true'
-        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
+        uses: nixbuild/nix-quick-install-action@2c9db80fb984ceb1bcaa77cdda3fdf8cfba92035 # v34
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
-          extra_nix_config: |
-            accept-flake-config = true
+          nix_conf: |
+            extra-substituters = https://nix-community.cachix.org https://numtide.cachix.org
+            extra-trusted-public-keys = nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs= numtide.cachix.org-1:2ps1kLBUWjxIneOy1Ik6cQjb41X0iXVXeHigGmycPPE=
+            keep-env-derivations = true
+            keep-outputs = true
+
+      - name: Restore and save Nix store
+        if: steps.check.outputs.skip != 'true'
+        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 5G
 
       - name: Compute version
         if: steps.check.outputs.skip != 'true'


### PR DESCRIPTION
## Summary
- `check.yaml` and `release.yaml` now restore/save the Nix store via `nix-community/cache-nix-action` (with `nixbuild/nix-quick-install-action`, both SHA-pinned), keyed on `flake.lock` + `*.nix` content — CI stops re-downloading the whole closure every run
- `check.yaml` owns cache hygiene: purges stale `nix-` caches and GCs the store to 5G before saving; `release.yaml` only restores/saves
- Security hardening that fell out of review: `accept-flake-config` is removed — on `pull_request` it let a PR's `flake.nix` `nixConfig` point CI at arbitrary substituters; the trusted caches (nix-community, numtide) are now enumerated in the workflow config instead
- `check.yaml` gains a concurrency group (superseded runs cancel) and explicit minimal permissions (`contents: read`, `actions: write` for cache purging)

## Test plan
- [ ] This PR's check run populates the cache (expect "cache miss" then save)
- [ ] Mergify auto-merges via the `merge-queue` label
- [ ] A subsequent run (e.g. push to main after merge) shows "restored from cache" and a faster `nix flake check`